### PR TITLE
Hotfix/optional kms key alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,23 @@ BUG FIXES:
 
 * KMS Key Alias preventing bucket creations when no KMS keys are created
 * Bucket policy preventing bucket creation when no IAM users are created
+
+## Release Version: 0.0.1
+
+BACKWARDS INCOMPATIBILITIES / NOTES:
+
+* Tested with terraform v0.11.7
+
+INITIAL RELEASE:
+
+* S3 Bucket: supports object versioning, lifecycle policy (on whole bucket) to remove object versions older than X days
+* IAM Management Users: Admin, Sync
+* Standard Users: User keys (directories) with KMS encryption for uploads
+
+IMPROVEMENTS:
+
+* N/A
+
+BUG FIXES:
+
+* N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,10 @@
-## Release Version: 0.0.1
+## Release Version: 0.0.2
 
 BACKWARDS INCOMPATIBILITIES / NOTES:
 
 * Tested with terraform v0.11.7
 
-INITIAL RELEASE:
 
-* S3 Bucket: supports object versioning, lifecycle policy (on whole bucket) to remove object versions older than X days
-* IAM Management Users: Admin, Sync
-* Standard Users: User keys (directories) with KMS encryption for uploads
 
 IMPROVEMENTS:
 
@@ -16,4 +12,5 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
-* N/A
+* KMS Key Alias preventing bucket creations when no KMS keys are created
+* Bucket policy preventing bucket creation when no IAM users are created

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## Release Version: 0.0.2
+
 # AWS S3 Bucket with IAM Access Module
 Terraform module which creates an S3 bucket with varying levels of access for IAM users.
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ N.b. Object versioning must be enabled to expire current versions and delete pre
 #### Bucket Lifecycle Prevent Destroy
 By default the prevent_destroy lifecycle is to "true" to prevent accidental bucket deletion via terraform.
 
+#### The KMS Bucket Policy 
+Setting the following variable to true, will apply the KMS bucket policy which disabled unencrypted uploads and enables uploads from users which possess KMS keys:
+```hcl
+enable_kms_bucket_policy = true #default = false
+```
+
 ### IAM Bucket Management Users 
 #### IAM User(s): S3 Bucket Full Permissions 
 Create IAM user(s) with full S3 bucket permissions (These users receive both management console and programmatic access):

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-## Release Version: 0.0.2
-
 # AWS S3 Bucket with IAM Access Module
 Terraform module which creates an S3 bucket with varying levels of access for IAM users.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # AWS S3 Bucket with IAM Access Module
 Terraform module which creates an S3 bucket with varying levels of access for IAM users.
 
-The following resources can be created:
+The following resources will be created:
 * An S3 bucket
+The following resources are optional:
 * IAM User(s)
 * IAM Policies
 * KMS Keys
+* KMS Bucket Policy
 
 ## Usage
 ### Specify this Module as Source
@@ -22,11 +24,7 @@ The argument for the region is required to specify where the resources should be
 ```hcl
 region = "eu-west-1" #default = "eu-central-1"
 ```
-#### PGP Key 
-A public PGP key (in binary format) is required for encrypting the IAM secret keys and KMS keys, as these are given in output (Please see outputs below):
-```hcl
-pgp_keyname = "C123654C.pgp"
-```
+
 ### S3 Bucket Arguments
 #### Bucket Name 
 Set the bucket name:
@@ -55,12 +53,13 @@ N.b. Object versioning must be enabled to expire current versions and delete pre
 By default the prevent_destroy lifecycle is to "true" to prevent accidental bucket deletion via terraform.
 
 #### The KMS Bucket Policy 
-Setting the following variable to true, will apply the KMS bucket policy which disabled unencrypted uploads and enables uploads from users which possess KMS keys:
+Setting the following variable to true, will apply the KMS bucket policy which disables unencrypted uploads and enables uploads from users which possess KMS keys (Pleae note if this variable is enabled, IAM Users are REQUIRED to be created, or the apply will fail!):
 ```hcl
 enable_kms_bucket_policy = true #default = false
 ```
 
 ### IAM Bucket Management Users 
+
 #### IAM User(s): S3 Bucket Full Permissions 
 Create IAM user(s) with full S3 bucket permissions (These users receive both management console and programmatic access):
 ```hcl
@@ -82,6 +81,12 @@ iam_user_s3_get_delete_names = ["sync_user", "sync_user2"]
 Create IAM user(s) with their own bucket key (directory) in the S3 bucket. These users are assigned their own KMS keys which enable them to upload files in encrypted format as well as to download them and decrypt. (These users receive only programmatic access, therefore FTP client software such as CloudBerry or Cyberduck should be used):
 ```hcl
 iam_user_s3_standard_names = ["Huey", "Dewey", "Louie"]
+```
+
+#### PGP Key 
+A public PGP key (in binary format) is required for encrypting the IAM secret keys and KMS keys, as these are given in output (Please see outputs below):
+```hcl
+pgp_keyname = "C123654C.pgp"
 ```
 
 ### Outputs 

--- a/kms_keys.tf
+++ b/kms_keys.tf
@@ -50,6 +50,7 @@ POLICY
 
 # create alias(') for the KMS key(s)
 resource "aws_kms_alias" "kmskeyaliases" {
+  count       = "${local.count_standard_user}"
   name          = "alias/${element(var.iam_user_s3_standard_names, count.index)}"
   target_key_id = "${element(aws_kms_key.kmskey.*.key_id, count.index)}"
 }

--- a/s3_bucket_policy.tf
+++ b/s3_bucket_policy.tf
@@ -1,5 +1,6 @@
 # S3 bucket policy
-resource "aws_s3_bucket_policy" "s3_bucket_policy" {
+resource "aws_s3_bucket_policy" "s3_kms_bucket_policy" {
+  count  = "${var.enable_kms_bucket_policy}"
   bucket = "${aws_s3_bucket.s3_bucket.id}"
   policy = "${data.template_file.bucket_policy.rendered}"
 }

--- a/variables_s3.tf
+++ b/variables_s3.tf
@@ -37,3 +37,7 @@ variable "s3_lifecycle_prevent_destroy" {
   description = "Prevent/allow terraform to destroy the bucket"
   default     = false
 }
+variable "enable_kms_bucket_policy" {
+  description = "Disalbed unencrypted uploads, enables user uploads with KMS keys"
+  default     = false
+}

--- a/variables_s3.tf
+++ b/variables_s3.tf
@@ -38,6 +38,6 @@ variable "s3_lifecycle_prevent_destroy" {
   default     = false
 }
 variable "enable_kms_bucket_policy" {
-  description = "Disalbed unencrypted uploads, enables user uploads with KMS keys"
+  description = "Disables unencrypted uploads, enables user uploads with KMS keys"
   default     = false
 }


### PR DESCRIPTION
Tested

Fixes following issues:
#2 
Bucket creation prevention when no kms keys are created
Bucket creation prevention when no IAM users are created (relates to kms bucket policy error which requires IAM users)